### PR TITLE
複合仕訳を複数行で表示するように改善

### DIFF
--- a/frontend/src/api/journalEntries.ts
+++ b/frontend/src/api/journalEntries.ts
@@ -1,0 +1,16 @@
+import { JournalEntry, API_BASE_URL } from "./types";
+
+export const getJournalEntries = async (): Promise<JournalEntry[]> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/journal-entries`);
+    if (!response.ok) {
+      // レスポンスのステータスが200番台以外の場合はエラーを投げる
+      throw new Error(`仕訳表の取得に失敗しました: ${response.status}`);
+    }
+    const journalEntry: JournalEntry[] = await response.json();
+    return journalEntry;
+  } catch (error) {
+    console.error("仕訳表の取得エラー:", error); // わかりやすくするためにコンソールに出力
+    throw error;
+  }
+};

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -63,3 +63,36 @@ export type DepartmentCode = {
 export type DepartmentName = {
   value: string;
 };
+
+// Journal Entry Value Objects (Kotlinのドメインモデルに合わせた型定義)
+export type JournalEntryDate = {
+  value: string;
+};
+
+export type JournalEntryNumber = {
+  value: string;
+};
+
+export type JournalEntryAmount = {
+  value: number;
+};
+
+export enum JournalEntryType {
+  DEBIT = "DEBIT",
+  CREDIT = "CREDIT",
+}
+
+// Journal Entry Detail
+export type JournalEntryDetail = {
+  account: Account;
+  journalEntryType: JournalEntryType;
+  amount: JournalEntryAmount;
+};
+
+// Journal Entry Header (メインの仕訳エンティティ)
+export type JournalEntry = {
+  date: JournalEntryDate;
+  number: JournalEntryNumber;
+  department: Department;
+  details: JournalEntryDetail[];
+};

--- a/frontend/src/app/journalEntry/_journalEntry.tsx/JournalEntry.tsx
+++ b/frontend/src/app/journalEntry/_journalEntry.tsx/JournalEntry.tsx
@@ -1,0 +1,72 @@
+import type { JournalEntry } from "@/api/types";
+import { JournalEntryType } from "@/api/types";
+
+type JournalEntryProps = {
+  journalEntries: JournalEntry[];
+};
+
+export default function JournalEntry({ journalEntries }: JournalEntryProps) {
+  return (
+    <>
+      <div className="w-full h-14 border-b border-gray-300 flex justify-between items-center">
+        <h1 className="mx-10 text-lg leading-14 text-gray-700 font-normal">
+          仕訳一覧
+        </h1>
+      </div>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="bg-gray-100 font-bold text-xs border-b border-gray-300">
+            <td className="p-4">日付</td>
+            <td className="p-4">仕訳No.</td>
+            <td className="p-4">部署</td>
+            <td className="p-4">借方勘定科目</td>
+            <td className="p-4">借方金額</td>
+            <td className="p-4">貸方勘定科目</td>
+            <td className="p-4">貸方金額</td>
+          </tr>
+        </thead>
+        <tbody>
+          {journalEntries.map((journalEntry: JournalEntry) => {
+            const debitDetails = journalEntry.details.filter(
+              (detail) => detail.journalEntryType === JournalEntryType.DEBIT
+            );
+            const creditDetails = journalEntry.details.filter(
+              (detail) => detail.journalEntryType === JournalEntryType.CREDIT
+            );
+
+            const maxRows = Math.max(debitDetails.length, creditDetails.length);
+
+            return Array.from({ length: maxRows }, (_, index) => (
+              <tr
+                key={`${journalEntry.number.value}-${index}`}
+                className="border-b border-gray-300"
+              >
+                <td className="p-3">
+                  {index === 0 ? journalEntry.date.value : ""}
+                </td>
+                <td className="p-3">
+                  {index === 0 ? journalEntry.number.value : ""}
+                </td>
+                <td className="p-3">
+                  {index === 0 ? journalEntry.department.name.value : ""}
+                </td>
+                <td className="p-3">
+                  {debitDetails[index]?.account.name.value || ""}
+                </td>
+                <td className="p-3">
+                  {debitDetails[index]?.amount.value.toLocaleString() || ""}
+                </td>
+                <td className="p-3">
+                  {creditDetails[index]?.account.name.value || ""}
+                </td>
+                <td className="p-3">
+                  {creditDetails[index]?.amount.value.toLocaleString() || ""}
+                </td>
+              </tr>
+            ));
+          })}
+        </tbody>
+      </table>
+    </>
+  );
+}

--- a/frontend/src/app/journalEntry/page.tsx
+++ b/frontend/src/app/journalEntry/page.tsx
@@ -1,0 +1,7 @@
+import JournalEntry from "./_journalEntry.tsx/JournalEntry";
+import { getJournalEntries } from "@/api/journalEntries";
+
+export default async function JournalEntries() {
+  const journalEntries = await getJournalEntries();
+  return <JournalEntry journalEntries={journalEntries} />;
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -18,6 +18,12 @@ export default function Sidebar() {
           >
             部署一覧
           </Link>
+          <Link
+            href="/journalEntry"
+            className="block no-underline text-sm text-gray-700 py-2 px-3 rounded hover:bg-gray-200"
+          >
+            仕訳表
+          </Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- JournalEntry.tsxの表示ロジックを修正し、複合仕訳（複数の借方・貸方明細を持つ仕訳）を複数行で表示するように改善
- 従来はカンマ区切りで1行表示していたが、各明細を個別の行で表示することで可読性を向上
- 借方・貸方の明細数の多い方に合わせて行数を自動決定

## 変更内容
- `Array.from()`を使用して複数行のテーブル行を生成
- 最初の行にのみ日付・仕訳番号・部署情報を表示
- オプショナルチェーニング（`?.`）を使用してundefined参照を安全に処理
- 各明細データを対応するインデックスで表示

## Test plan
- [ ] 単一明細の仕訳が正常に表示されることを確認
- [ ] 複合仕訳（借方複数・貸方単一）が複数行で正しく表示されることを確認
- [ ] 複合仕訳（借方単一・貸方複数）が複数行で正しく表示されることを確認
- [ ] 複合仕訳（借方複数・貸方複数）が複数行で正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)